### PR TITLE
Add ks_shutdown() to mod_vosk_shutdown()

### DIFF
--- a/src/mod/asr_tts/mod_vosk/mod_vosk.c
+++ b/src/mod/asr_tts/mod_vosk/mod_vosk.c
@@ -339,6 +339,7 @@ SWITCH_MODULE_LOAD_FUNCTION(mod_vosk_load)
 SWITCH_MODULE_SHUTDOWN_FUNCTION(mod_vosk_shutdown)
 {
 	ks_pool_close(&globals.ks_pool);
+	ks_shutdown();
 
 	switch_event_unbind(&NODE);
 	return SWITCH_STATUS_UNLOAD;


### PR DESCRIPTION
This patch prevents FreeSWITCH from segfaulting on mod_vosk unload/load